### PR TITLE
Day component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-range",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A React component for choosing dates and date ranges.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "react-date-range",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A React component for choosing dates and date ranges.",
   "main": "dist/index.js",
   "scripts": {
     "start": "yarn build:css & styleguidist server",
     "build": "yarn build:css & yarn build:js & styleguidist build",
+    "prepare": "yarn build",
     "build:css": "postcss 'src/styles.scss' -d dist --ext css & postcss 'src/theme/*.scss' -d 'dist/theme' --ext css",
     "build:js": "babel ./src --out-dir ./dist --ignore test.js",
     "lint": "eslint 'src/**/*.js'",

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -393,6 +393,7 @@ class Calendar extends PureComponent {
 
     const ranges = this.props.ranges.map((range, i) => ({
       ...range,
+      index: i,
       color: range.color || rangeColors[i] || color,
     }));
     return (

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -142,6 +142,7 @@ DateRange.propTypes = {
   className: PropTypes.string,
   ranges: PropTypes.arrayOf(rangeShape),
   moveRangeOnFirstSelection: PropTypes.bool,
+  DayComponent: PropTypes.func,
 };
 
 export default DateRange;

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -102,16 +102,10 @@ class DayCell extends Component {
       />
     );
   };
-  renderSelectionPlaceholders = () => {
-    const { styles, ranges, day } = this.props;
-    if (this.props.displayMode === 'date') {
-      let isSelected = isSameDay(this.props.day, this.props.date);
-      return isSelected ? (
-        <span className={styles.selected} style={{ color: this.props.color }} />
-      ) : null;
-    }
+  getInRanges = () => {
+    const { ranges, day } = this.props;
 
-    const inRanges = ranges.reduce((result, range) => {
+    return ranges.reduce((result, range) => {
       let startDate = range.startDate;
       let endDate = range.endDate;
       if (startDate && endDate && isBefore(endDate, startDate)) {
@@ -136,8 +130,19 @@ class DayCell extends Component {
       }
       return result;
     }, []);
+  }
+  getIsSelected = () => {
+    return this.props.displayMode === 'date' && isSameDay(this.props.day, this.props.date)
+  }
+  renderSelectionPlaceholders = () => {
+    const { styles } = this.props;
+    if (this.props.displayMode === 'date') {
+      return this.getIsSelected() ? (
+        <span className={styles.selected} style={{ color: this.props.color }} />
+      ) : null;
+    }
 
-    return inRanges.map((range, i) => (
+    return this.getInRanges.map((range, i) => (
       <span
         key={i}
         className={classnames({
@@ -150,6 +155,7 @@ class DayCell extends Component {
     ));
   };
   render() {
+    const { DayComponent } = this.props;
     return (
       <button
         type="button"
@@ -165,11 +171,22 @@ class DayCell extends Component {
         className={this.getClassNames(this.props.styles)}
         {...(this.props.disabled || this.props.isPassive ? { tabIndex: -1 } : {})}
         style={{ color: this.props.color }}>
-        {this.renderSelectionPlaceholders()}
-        {this.renderPreviewPlaceholder()}
-        <span className={this.props.styles.dayNumber}>
-          <span>{format(this.props.day, this.props.dayDisplayFormat)}</span>
-        </span>
+          {DayComponent ? (
+            <DayComponent
+              {...this.props}
+              {...this.state}
+              inRanges={this.getInRanges()}
+              isSelected={this.getIsSelected()}
+            />
+          ) : (
+            <>
+              {this.renderSelectionPlaceholders()}
+              {this.renderPreviewPlaceholder()}
+              <span className={this.props.styles.dayNumber}>
+                <span>{format(this.props.day, this.props.dayDisplayFormat)}</span>
+              </span>
+            </>
+          )}
       </button>
     );
   }
@@ -213,6 +230,7 @@ DayCell.propTypes = {
   onMouseDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   onMouseEnter: PropTypes.func,
+  DayComponent: PropTypes.func
 };
 
 export default DayCell;

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { startOfDay, format, isSameDay, isAfter, isBefore, endOfDay } from 'date-fns';
 
+export const DATE_FORMAT = 'yyyy-MM-dd'
+
 class DayCell extends Component {
   constructor(props, context) {
     super(props, context);
@@ -159,6 +161,7 @@ class DayCell extends Component {
     return (
       <button
         type="button"
+        data-testid={`day-${format(this.props.day, DATE_FORMAT)}`}
         onMouseEnter={this.handleMouseEvent}
         onMouseLeave={this.handleMouseEvent}
         onFocus={this.handleMouseEvent}

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -143,6 +143,7 @@ Month.propTypes = {
   showWeekDays: PropTypes.bool,
   showMonthName: PropTypes.bool,
   fixedHeight: PropTypes.bool,
+  DayComponent: PropTypes.func
 };
 
 export default Month;

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,10 +43,14 @@ export function calcFocusDate(currentFocusedDate, props) {
 
   const firstShownDate = startOfMonth(currentFocusedDate)
   const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months))
+  console.log(lastShownDate)
 
   // if we are still in view of target date, don't shift calendar
   if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {
+    console.log('within')
     return currentFocusedDate;
+  } else {
+    console.log('without')
   }
 
   return targetDate;

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ export function calcFocusDate(currentFocusedDate, props) {
   }
 
   const firstShownDate = startOfMonth(currentFocusedDate)
-  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months))
+  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months - 1))
 
   // if we are still in view of target date, don't shift calendar
   if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,8 @@ import {
   addDays,
   addMonths,
   isAfter,
-  isBefore
+  isBefore,
+  isSameDay
 } from 'date-fns';
 export function calcFocusDate(currentFocusedDate, props) {
   const { shownDate, date, months, ranges, focusedRange, displayMode } = props;
@@ -45,7 +46,10 @@ export function calcFocusDate(currentFocusedDate, props) {
   const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months - 1))
 
   // if we are still in view of target date, don't shift calendar
-  if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {
+  if (
+    (isSameDay(targetInterval.start, firstShownDate) || isAfter(targetInterval.start, firstShownDate)) &&
+    (isSameDay(targetInterval.end, lastShownDate) || isBefore(targetInterval.end, lastShownDate))
+  ) {
     return currentFocusedDate;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ export function calcFocusDate(currentFocusedDate, props) {
   }
 
   const firstShownDate = startOfMonth(currentFocusedDate)
-  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months - 1))
+  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months))
 
   // if we are still in view of target date, don't shift calendar
   if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,15 +42,11 @@ export function calcFocusDate(currentFocusedDate, props) {
   }
 
   const firstShownDate = startOfMonth(currentFocusedDate)
-  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months))
-  console.log(lastShownDate)
+  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months - 1))
 
   // if we are still in view of target date, don't shift calendar
   if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {
-    console.log('within')
     return currentFocusedDate;
-  } else {
-    console.log('without')
   }
 
   return targetDate;

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,8 +7,10 @@ import {
   differenceInCalendarDays,
   differenceInCalendarMonths,
   addDays,
+  addMonths,
+  isAfter,
+  isBefore
 } from 'date-fns';
-
 export function calcFocusDate(currentFocusedDate, props) {
   const { shownDate, date, months, ranges, focusedRange, displayMode } = props;
   // find primary date according the props
@@ -38,6 +40,15 @@ export function calcFocusDate(currentFocusedDate, props) {
     // don't change focused if new selection in view area
     return currentFocusedDate;
   }
+
+  const firstShownDate = startOfMonth(currentFocusedDate)
+  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months))
+
+  // if we are still in view of target date, don't shift calendar
+  if (isAfter(targetInterval.start, firstShownDate) && isBefore(targetInterval.end, lastShownDate)) {
+    return currentFocusedDate;
+  }
+
   return targetDate;
 }
 


### PR DESCRIPTION
Allows supplying a day component.
Adds index to range information.
Does not shift the calendar if the month of the day you clicked on or input via text is already in view.